### PR TITLE
PowerPC64 fix

### DIFF
--- a/src/pyhw/backend/cpu/linux.py
+++ b/src/pyhw/backend/cpu/linux.py
@@ -48,7 +48,20 @@ class CPUDetectLinux:
             else:
                 for line in cpu_info.split("\n"):
                     if line.startswith("cpu MHz") or line.startswith("clock"):
-                        self.__cpuInfo.frequency = f"{round(float(line.split(':')[1].strip()) / 1000, 2)} Ghz"  # Ghz
+                        value_str = line.split(':')[1].strip()
+                        try:
+                            freq_value = float(value_str)
+                            self.__cpuInfo.frequency = f"{round(freq_value / 1000, 2)} Ghz"
+                        except ValueError:
+                            match = re.search(r'(\d+(?:\.\d+)?)', value_str)
+                            if match:
+                                freq_value = float(match.group(1))
+                                if 'MHz' in value_str:
+                                    self.__cpuInfo.frequency = f"{round(freq_value / 1000, 2)} Ghz"
+                                elif 'GHz' in value_str:
+                                    self.__cpuInfo.frequency = f"{round(freq_value, 2)} Ghz"
+                                else:
+                                    self.__cpuInfo.frequency = f"{round(freq_value / 1000, 2)} Ghz"
                         break
 
     def __modelClean(self):

--- a/src/pyhw/backend/gpu/linux.py
+++ b/src/pyhw/backend/gpu/linux.py
@@ -39,6 +39,10 @@ class GPUDetectLinux:
                     device_name = f"{device.vendor_name} {device.device_name} [{device.subsystem_device_name}] {core_print}"
                 else:
                     device_name = f"{device.vendor_name} {device.device_name} {core_print}"
+
+                if not device_name.strip():
+                    device_name = f"{device.driver_name}"
+
                 self.__gpuInfo.gpus.append(self.__gpuNameClean(device_name))
                 self.__gpuInfo.number += 1
 

--- a/src/pyhw/backend/gpu/linux.py
+++ b/src/pyhw/backend/gpu/linux.py
@@ -41,7 +41,7 @@ class GPUDetectLinux:
                     device_name = f"{device.vendor_name} {device.device_name} {core_print}"
 
                 if not device_name.strip():
-                    device_name = f"{device.driver_name}"
+                    device_name = f"{device.class_name}"
 
                 self.__gpuInfo.gpus.append(self.__gpuNameClean(device_name))
                 self.__gpuInfo.number += 1


### PR DESCRIPTION
This pull request improves the robustness of the CPU and GPU information parsing logic in the `pyhw` backend for Linux. The most important changes include adding error handling for CPU frequency parsing and ensuring a fallback mechanism for GPU device naming when no name is provided.

### Improvements to CPU information parsing:

* [`src/pyhw/backend/cpu/linux.py`](diffhunk://#diff-4c249e4128b7a4c10cc0bf46a54bb3ef405275cb2cd4924e8ef61bede7494ed5L51-R64): Enhanced the `__getCPUInfo` method to handle cases where CPU frequency values are not directly parsable as floats. It now attempts to extract numeric values using regex and adjusts the frequency unit accordingly (e.g., MHz to GHz). This prevents crashes due to unexpected formats.

### Improvements to GPU information parsing:

* [`src/pyhw/backend/gpu/linux.py`](diffhunk://#diff-c3f663eafb1675239ef2e18b268430830ba6c160b9ba8d436c8422368fba60c0R42-R45): Updated the `__getGPUInfo` method to include a fallback mechanism for GPU device naming. If the constructed `device_name` is empty or contains only whitespace, it defaults to using the `device.class_name` as the name. This ensures that all GPUs are assigned a valid name.