### PR TITLE
macOS NIC backend enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ lib:
 	cd src/pyhw/library/iokitHostLib && make lib
 	cd src/pyhw/library/nvmlGPULib && make lib
 	cd src/pyhw/library/iokitCPULib && make lib
+	cd src/pyhw/library/iokitNICLib && make lib
 clean:
 	-rm -rf dist/
 build: clean lib

--- a/src/pyhw/backend/nic/macos.py
+++ b/src/pyhw/backend/nic/macos.py
@@ -11,15 +11,106 @@ class NICDetectMacOS:
         return self.__nicInfo
 
     def __getNICInfo(self):
-        # Placeholder for a more advanced method.
         try:
-            interface = subprocess.run(["bash", "-c", "route get default | grep interface"], capture_output=True, text=True).stdout.strip().split(":")[1]
-            if_ip = subprocess.run(["bash", "-c", f"ipconfig getifaddr {interface}"], capture_output=True, text=True).stdout.strip()
-            self.__nicInfo.nics.append(f"{interface} @ {if_ip}")
+            # Get default interface
+            cmd_get_interface = "route get default | grep interface"
+            interface_output = subprocess.run(["bash", "-c", cmd_get_interface],
+                                              capture_output=True, text=True).stdout.strip()
+            interface = interface_output.split(":")[1].strip()
+
+            # Get IP address
+            if_ip = subprocess.run(["bash", "-c", f"ipconfig getifaddr {interface}"],
+                                   capture_output=True, text=True).stdout.strip()
+
+            # Get interface type and link speed
+            link_info = self.__getLinkInfo(interface)
+
+            # Add all information to nicInfo
+            self.__nicInfo.nics.append(f"{interface} @ {if_ip} - {link_info}")
             self.__nicInfo.number += 1
-        except:
+        except Exception as e:
             self.__handleError()
 
+    def __getLinkInfo(self, interface):
+        try:
+            # Check if interface is wireless
+            is_wifi_cmd = f"networksetup -getairportpower {interface} 2>/dev/null"
+            is_wifi_result = subprocess.run(["bash", "-c", is_wifi_cmd],
+                                            capture_output=True, text=True).returncode
+
+            if is_wifi_result == 0:  # This is a Wi-Fi interface
+                speed, channel, band = self.__getWifiInfo(interface)
+                return f"Wi-Fi {band} ({speed} Mbps)"
+            else:
+                # For wired connections, get link speed using networksetup
+                media_cmd = f"networksetup -getmedia {interface} | grep 'Active'"
+                media_info = subprocess.run(["bash", "-c", media_cmd],
+                                            capture_output=True, text=True).stdout.strip()
+
+                if media_info:
+                    parts = media_info.split(':', 1)
+                    if len(parts) > 1:
+                        # Extract "2500Base-T <full-duplex>" part
+                        media_details = parts[1].strip()
+
+                        # Parse the speed part (e.g., "2500Base-T")
+                        speed_part = media_details.split()[0] if media_details else ""
+
+                        if "2500Base-T" in speed_part:
+                            return "Wired (2.5 Gbps)"
+                        elif "1000Base-T" in speed_part:
+                            return "Wired (1 Gbps)"
+                        elif "100Base-T" in speed_part:
+                            return "Wired (100 Mbps)"
+                        elif "10000Base-T" in speed_part:
+                            return "Wired (10 Gbps)"
+                        elif "Base-T" in speed_part or "base-T" in speed_part:
+                            # Extract the numeric part from formats like "5000Base-T"
+                            import re
+                            speed_match = re.search(r'(\d+)(?:Base-T|base-T)', speed_part)
+                            if speed_match:
+                                speed_value = int(speed_match.group(1))
+                                if speed_value >= 1000:
+                                    return f"Wired ({speed_value / 1000:.1f} Gbps)"
+                                else:
+                                    return f"Wired ({speed_value} Mbps)"
+                            return f"Wired ({speed_part})"
+        except:
+            return "Unknown connection type"
+
+    def __getWifiInfo(self, interface):
+        # Use system_profiler which doesn't require sudo
+        profiler_cmd = f"system_profiler SPAirPortDataType -json"
+        wifi_data = subprocess.run(["bash", "-c", profiler_cmd],
+                                   capture_output=True, text=True).stdout
+
+        try:
+            import json
+            data = json.loads(wifi_data)
+            # Extract WiFi information
+            airport_info = data.get('SPAirPortDataType', [{}])[0]
+            interfaces = airport_info.get('spairport_airport_interfaces', [{}])
+
+            # Look for the matching interface
+            for iface in interfaces:
+                if interface in iface.get('_name', ''):
+                    speed = iface.get('spairport_airport_tx_rate', 'Unknown')
+                    channel = iface.get('spairport_airport_channel', 'Unknown')
+                    band = ""
+
+                    if channel and isinstance(channel, (int, str)):
+                        chan_num = int(str(channel).split(',')[0])
+                        if chan_num <= 14:
+                            band = "2.4GHz"
+                        else:
+                            band = "5GHz"
+
+                    return speed, channel, band
+
+            return "Unknown", "Unknown", "Unknown"
+        except Exception as e:
+            return "Unknown", "Unknown", "Unknown"
+
     def __handleError(self):
-        self.__nicInfo.nics.append("en0")
+        self.__nicInfo.nics.append("en0 - Unknown connection")
         self.__nicInfo.number = 1

--- a/src/pyhw/backend/nic/macos.py
+++ b/src/pyhw/backend/nic/macos.py
@@ -72,8 +72,7 @@ class NICDetectMacOS:
                                       wifi_standard):
 
                     if is_wifi.value:
-                        wifi_info = f"{wifi_standard.value.decode('utf-8')} {band.value.decode('utf-8')}"
-                        conn_info = f"{conn_type.value.decode('utf-8')} ({wifi_info}, {speed.value} Mbps)"
+                        conn_info = f"{conn_type.value.decode('utf-8')} 802.11{wifi_standard.value.decode('utf-8')} ({band.value.decode('utf-8')} {speed.value} Mbps)"
                     else:
                         conn_info = conn_type.value.decode('utf-8')
 
@@ -89,7 +88,6 @@ class NICDetectMacOS:
             else:
                 return False
 
-            return False
         except Exception as e:
             # print(f"An error occurred while getting NIC info using IOKit: {e}")
             return False

--- a/src/pyhw/library/iokitNICLib/Makefile
+++ b/src/pyhw/library/iokitNICLib/Makefile
@@ -1,0 +1,25 @@
+CC = swiftc
+CFLAG = -framework IOKit
+
+MACOS_VERSION = 11
+ARCH_X86_64 = -target x86_64-apple-macos$(MACOS_VERSION)
+ARCH_ARM64 = -target arm64-apple-macos$(MACOS_VERSION)
+
+target = iokitNICLib
+src = $(target).swift
+
+x86_64_lib: $(src)
+	$(CC) -emit-library $(src) $(CFLAG) $(ARCH_X86_64) -o $(target)_x86_64.dylib
+
+arm_lib: $(src)
+	$(CC) -emit-library $(src) $(CFLAG) $(ARCH_ARM64) -o $(target)_arm64.dylib
+
+lib: x86_64_lib arm_lib
+	-mkdir -p ../lib
+	lipo -create $(target)_x86_64.dylib $(target)_arm64.dylib -output ../lib/$(target).dylib
+	-rm $(target)_x86_64.dylib $(target)_arm64.dylib
+
+
+.PHONY: clean
+clean:
+	-rm $(target)_x86_64.dylib $(target)_arm64.dylib $(target).dylib

--- a/src/pyhw/library/iokitNICLib/iokitNICLib.swift
+++ b/src/pyhw/library/iokitNICLib/iokitNICLib.swift
@@ -1,0 +1,279 @@
+import Foundation
+import CoreWLAN
+import Network
+import SystemConfiguration
+import IOKit
+import IOKit.network
+
+@_cdecl("getNetworkInfo")
+public func getNetworkInfo(_ interfaceName: UnsafePointer<Int8>,
+                         isWifi: UnsafeMutablePointer<Bool>,
+                         ipAddress: UnsafeMutablePointer<Int8>,
+                         speed: UnsafeMutablePointer<Int32>,
+                         band: UnsafeMutablePointer<Int8>,
+                         channel: UnsafeMutablePointer<Int8>,
+                         connectionType: UnsafeMutablePointer<Int8>) -> Bool {
+
+    let interfaceNameStr = String(cString: interfaceName)
+
+    // 默认设置isWifi为false
+    isWifi.pointee = false
+
+    // 获取IP地址
+    if let ip = getIPAddress(for: interfaceNameStr) {
+        strncpy(ipAddress, ip, 16)
+    } else {
+        strncpy(ipAddress, "Unknown", 16)
+    }
+
+    // 检查是否为WiFi接口
+    if let wifiInterface = CWWiFiClient.shared().interface(withName: interfaceNameStr) {
+        isWifi.pointee = true
+
+        // 获取WiFi信息
+        if let wifiInfo = getWifiInfo(interface: wifiInterface) {
+            speed.pointee = Int32(wifiInfo.speed)
+            strncpy(band, wifiInfo.band, 10)
+            strncpy(channel, wifiInfo.channel, 20)
+            strncpy(connectionType, "Wi-Fi", 20)
+        } else {
+            speed.pointee = 0
+            strncpy(band, "Unknown", 10)
+            strncpy(channel, "Unknown", 20)
+            strncpy(connectionType, "Wi-Fi", 20)
+        }
+
+        return true
+    } else {
+        // 有线网络信息获取
+        if let wiredSpeed = getWiredSpeed(for: interfaceNameStr) {
+            speed.pointee = Int32(wiredSpeed)
+
+            // 设置连接类型
+            if wiredSpeed >= 10000 {
+                strncpy(connectionType, "Wired (10 Gbps)", 20)
+            } else if wiredSpeed >= 5000 {
+                strncpy(connectionType, "Wired (5 Gbps)", 20)
+            } else if wiredSpeed >= 2500 {
+                strncpy(connectionType, "Wired (2.5 Gbps)", 20)
+            } else if wiredSpeed >= 1000 {
+                strncpy(connectionType, "Wired (1 Gbps)", 20)
+            } else if wiredSpeed >= 100 {
+                strncpy(connectionType, "Wired (100 Mbps)", 20)
+            } else {
+                strncpy(connectionType, "Wired", 20)
+            }
+
+            strncpy(band, "N/A", 10)
+            strncpy(channel, "N/A", 20)
+
+            return true
+        }
+    }
+
+    // 如果没有获取到有效信息
+    speed.pointee = 0
+    strncpy(band, "Unknown", 10)
+    strncpy(channel, "Unknown", 20)
+    strncpy(connectionType, "Unknown", 20)
+
+    return false
+}
+
+func getIPAddress(for interface_name: String) -> String? {
+    var address: String?
+    var ifaddr: UnsafeMutablePointer<ifaddrs>?
+
+    guard getifaddrs(&ifaddr) == 0 else { return nil }
+    defer { freeifaddrs(ifaddr) }
+
+    var ptr = ifaddr
+    while ptr != nil {
+        defer { ptr = ptr?.pointee.ifa_next }
+
+        let interface = ptr?.pointee
+        let addrFamily = interface?.ifa_addr.pointee.sa_family
+        if addrFamily == UInt8(AF_INET) {  // 只获取IPv4地址
+            let name = String(cString: (interface?.ifa_name)!)
+            if name == interface_name {
+                var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+                getnameinfo(interface?.ifa_addr, socklen_t((interface?.ifa_addr.pointee.sa_len)!),
+                           &hostname, socklen_t(hostname.count),
+                           nil, 0, NI_NUMERICHOST)
+                address = String(cString: hostname)
+            }
+        }
+    }
+
+    return address
+}
+
+struct WiFiInfo {
+    var speed: Int
+    var band: String
+    var channel: String
+}
+
+func getWifiInfo(interface: CWInterface) -> WiFiInfo? {
+    guard interface.powerOn() else { return nil }
+
+    let speed = Int(interface.transmitRate())
+    var band = "Unknown"
+    var channel = "Unknown"
+
+    if let channelInfo = interface.wlanChannel() {
+        channel = "\(channelInfo.channelNumber)"
+
+        // 确定频段
+        if channelInfo.channelBand == .band2GHz {
+            band = "2.4GHz"
+        } else if channelInfo.channelBand == .band5GHz {
+            band = "5GHz"
+        } else if #available(macOS 13.0, *), channelInfo.channelBand == .band6GHz {
+            band = "6GHz"
+        }
+    }
+
+    return WiFiInfo(speed: speed, band: band, channel: channel)
+}
+
+func getWiredSpeed(for interface: String) -> Int? {
+    // 使用IOKit获取有线接口速度
+    let matchingDict = IOServiceMatching("IONetworkInterface") as NSMutableDictionary
+
+    var iterator: io_iterator_t = 0
+    if IOServiceGetMatchingServices(kIOMasterPortDefault, matchingDict, &iterator) != KERN_SUCCESS {
+        return nil
+    }
+    defer { IOObjectRelease(iterator) }
+
+    var service: io_object_t = 0
+    var speed: Int? = nil
+
+    repeat {
+        service = IOIteratorNext(iterator)
+        guard service != 0 else { break }
+        defer { IOObjectRelease(service) }
+
+        var parentService: io_object_t = 0
+        if IORegistryEntryGetParentEntry(service, kIOServicePlane, &parentService) == KERN_SUCCESS {
+            defer { IOObjectRelease(parentService) }
+
+            // 获取接口名称
+            let interfaceNameRef = IORegistryEntryCreateCFProperty(service, "BSD Name" as CFString, kCFAllocatorDefault, 0)
+            if let interfaceNameRef = interfaceNameRef,
+               let ifName = (interfaceNameRef.takeRetainedValue() as? String),
+               ifName == interface {
+
+                // 检查接口是否为有线接口
+                let interfaceTypeRef = IORegistryEntryCreateCFProperty(parentService, "IOInterfaceType" as CFString, kCFAllocatorDefault, 0)
+                if let interfaceTypeRef = interfaceTypeRef,
+                   let interfaceType = interfaceTypeRef.takeRetainedValue() as? Int,
+                   interfaceType == 6 { // 6是有线以太网接口
+
+                    // 获取链接速度
+                    let linkStatusRef = IORegistryEntryCreateCFProperty(parentService, "IOLinkSpeed" as CFString, kCFAllocatorDefault, 0)
+                    if let linkStatusRef = linkStatusRef,
+                       let linkSpeed = linkStatusRef.takeRetainedValue() as? Int {
+                        // IOLinkSpeed是以bps为单位，需要转换为Mbps
+                        speed = linkSpeed / 1_000_000
+                    }
+
+                    // 如果无法通过IOLinkSpeed获取，尝试其他属性
+                    if speed == nil || speed == 0 {
+                        // 尝试获取媒体类型
+                        let mediaDict = IORegistryEntryCreateCFProperty(parentService, "IOMediaAdditions" as CFString, kCFAllocatorDefault, 0)
+                        if let mediaDict = mediaDict,
+                           let mediaDictValue = mediaDict.takeRetainedValue() as? [String: Any],
+                           let activeSubkey = mediaDictValue["Active"] as? [String: Any] {
+                            // 通常包含如"1000baseT"的信息
+                            if let speedStr = activeSubkey["String"] as? String {
+                                if speedStr.contains("10000base") {
+                                    speed = 10000
+                                } else if speedStr.contains("5000base") {
+                                    speed = 5000
+                                } else if speedStr.contains("2500base") {
+                                    speed = 2500
+                                } else if speedStr.contains("1000base") {
+                                    speed = 1000
+                                } else if speedStr.contains("100base") {
+                                    speed = 100
+                                } else if speedStr.contains("10base") {
+                                    speed = 10
+                                }
+                            }
+                        }
+                    }
+
+                    break
+                }
+            }
+        }
+    } while service != 0
+
+    // 如果找不到速度，使用备用方法
+    if speed == nil {
+        // 使用命令行工具作为备选
+        let task = Process()
+        task.launchPath = "/usr/sbin/networksetup"
+        task.arguments = ["-getmedia", interface]
+
+        let pipe = Pipe()
+        task.standardOutput = pipe
+
+        do {
+            try task.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: data, encoding: .utf8) ?? ""
+
+            if output.contains("2500baseT") {
+                speed = 2500
+            } else if output.contains("1000baseT") {
+                speed = 1000
+            } else if output.contains("100baseT") {
+                speed = 100
+            } else if output.contains("10000baseT") {
+                speed = 10000
+            } else if output.contains("5000baseT") {
+                speed = 5000
+            }
+        } catch {
+            print("备用方法错误: \(error)")
+        }
+    }
+
+    return speed
+}
+
+@_cdecl("getDefaultInterface")
+public func getDefaultInterface(_ interfaceName: UnsafeMutablePointer<Int8>) -> Bool {
+    var defaultRouteInterface: String?
+
+    // 优先使用命令行方法获取默认路由接口
+    let task = Process()
+    task.launchPath = "/bin/bash"
+    task.arguments = ["-c", "route -n get default 2>/dev/null | grep 'interface:' | awk '{print $2}'"]
+
+    let pipe = Pipe()
+    task.standardOutput = pipe
+
+    do {
+        try task.run()
+        task.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        if let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !output.isEmpty {
+            defaultRouteInterface = output
+        }
+    } catch {
+        print("获取默认路由接口错误: \(error)")
+    }
+
+    // 如果还是找不到，使用en0作为备选
+    defaultRouteInterface = defaultRouteInterface ?? "en0"
+
+    // 复制接口名称到输出参数
+    strncpy(interfaceName, defaultRouteInterface!, 16)
+
+    return true
+}

--- a/src/pyhw/library/test/iokitNICLibTest.py
+++ b/src/pyhw/library/test/iokitNICLibTest.py
@@ -1,0 +1,78 @@
+import ctypes
+from ctypes import c_char_p, c_bool, c_int32, c_char, byref, create_string_buffer
+import os
+
+
+def main():
+    # 获取当前文件所在的目录
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    # 构建动态库路径（假设动态库在上级目录的lib文件夹中）
+    lib_path = os.path.join(current_dir, "../lib/iokitNICLib.dylib")
+
+    try:
+        # 加载动态库
+        lib = ctypes.CDLL(lib_path)
+
+        # 设置函数参数和返回类型
+        lib.getDefaultInterface.argtypes = [c_char_p]
+        lib.getDefaultInterface.restype = c_bool
+
+        lib.getNetworkInfo.argtypes = [c_char_p, ctypes.POINTER(c_bool),
+                                       c_char_p, ctypes.POINTER(c_int32),
+                                       c_char_p, c_char_p, c_char_p]
+        lib.getNetworkInfo.restype = c_bool
+
+        # 获取默认接口
+        interface = create_string_buffer(32)
+        if lib.getDefaultInterface(interface):
+            interface_str = interface.value.decode('utf-8')
+            print(f"默认网络接口: {interface_str}")
+
+            # 获取网络信息
+            is_wifi = c_bool(False)
+            ip_address = create_string_buffer(32)
+            speed = c_int32(0)
+            band = create_string_buffer(16)
+            channel = create_string_buffer(32)
+            conn_type = create_string_buffer(32)
+
+            if lib.getNetworkInfo(interface_str.encode('utf-8'),
+                                  byref(is_wifi),
+                                  ip_address,
+                                  byref(speed),
+                                  band,
+                                  channel,
+                                  conn_type):
+
+                # 输出获取到的信息
+                print("=== 网络信息 ===")
+                print(f"接口: {interface_str}")
+                print(f"IP地址: {ip_address.value.decode('utf-8')}")
+                print(f"连接类型: {conn_type.value.decode('utf-8')}")
+                print(f"速度: {speed.value} Mbps")
+
+                if is_wifi.value:
+                    print(f"Wi-Fi频段: {band.value.decode('utf-8')}")
+                    print(f"信道: {channel.value.decode('utf-8')}")
+
+                # 格式化输出（与nicInfo类似的格式）
+                if is_wifi.value:
+                    conn_info = f"{conn_type.value.decode('utf-8')} {band.value.decode('utf-8')} ({speed.value} Mbps)"
+                else:
+                    conn_info = conn_type.value.decode('utf-8')
+
+                formatted_output = f"{interface_str} @ {ip_address.value.decode('utf-8')} - {conn_info}"
+                print("\n格式化输出:")
+                print(formatted_output)
+            else:
+                print(f"无法获取接口 {interface_str} 的网络信息")
+        else:
+            print("无法获取默认网络接口")
+
+    except Exception as e:
+        print(f"错误: {e}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/pyhw/library/test/iokitNICLibTest.py
+++ b/src/pyhw/library/test/iokitNICLibTest.py
@@ -19,7 +19,7 @@ def main():
 
         lib.getNetworkInfo.argtypes = [c_char_p, ctypes.POINTER(c_bool),
                                        c_char_p, ctypes.POINTER(c_int32),
-                                       c_char_p, c_char_p, c_char_p]
+                                       c_char_p, c_char_p, c_char_p, c_char_p]
         lib.getNetworkInfo.restype = c_bool
 
         # 获取默认接口
@@ -35,6 +35,7 @@ def main():
             band = create_string_buffer(16)
             channel = create_string_buffer(32)
             conn_type = create_string_buffer(32)
+            wifi_standard = create_string_buffer(16)
 
             if lib.getNetworkInfo(interface_str.encode('utf-8'),
                                   byref(is_wifi),
@@ -42,7 +43,8 @@ def main():
                                   byref(speed),
                                   band,
                                   channel,
-                                  conn_type):
+                                  conn_type,
+                                  wifi_standard):
 
                 # 输出获取到的信息
                 print("=== 网络信息 ===")
@@ -54,10 +56,12 @@ def main():
                 if is_wifi.value:
                     print(f"Wi-Fi频段: {band.value.decode('utf-8')}")
                     print(f"信道: {channel.value.decode('utf-8')}")
+                    print(f"Wi-Fi标准: {wifi_standard.value.decode('utf-8')}")
 
                 # 格式化输出（与nicInfo类似的格式）
                 if is_wifi.value:
-                    conn_info = f"{conn_type.value.decode('utf-8')} {band.value.decode('utf-8')} ({speed.value} Mbps)"
+                    wifi_info = f"{wifi_standard.value.decode('utf-8')} {band.value.decode('utf-8')}"
+                    conn_info = f"{conn_type.value.decode('utf-8')} ({wifi_info}, {speed.value} Mbps)"
                 else:
                     conn_info = conn_type.value.decode('utf-8')
 

--- a/src/pyhw/library/test/iokitNICLibTest.py
+++ b/src/pyhw/library/test/iokitNICLibTest.py
@@ -4,16 +4,12 @@ import os
 
 
 def main():
-    # 获取当前文件所在的目录
     current_dir = os.path.dirname(os.path.abspath(__file__))
-    # 构建动态库路径（假设动态库在上级目录的lib文件夹中）
     lib_path = os.path.join(current_dir, "../lib/iokitNICLib.dylib")
 
     try:
-        # 加载动态库
         lib = ctypes.CDLL(lib_path)
 
-        # 设置函数参数和返回类型
         lib.getDefaultInterface.argtypes = [c_char_p]
         lib.getDefaultInterface.restype = c_bool
 
@@ -22,13 +18,13 @@ def main():
                                        c_char_p, c_char_p, c_char_p, c_char_p]
         lib.getNetworkInfo.restype = c_bool
 
-        # 获取默认接口
         interface = create_string_buffer(32)
         if lib.getDefaultInterface(interface):
             interface_str = interface.value.decode('utf-8')
+
+            # interface_str = "en1"
             print(f"默认网络接口: {interface_str}")
 
-            # 获取网络信息
             is_wifi = c_bool(False)
             ip_address = create_string_buffer(32)
             speed = c_int32(0)
@@ -46,7 +42,6 @@ def main():
                                   conn_type,
                                   wifi_standard):
 
-                # 输出获取到的信息
                 print("=== 网络信息 ===")
                 print(f"接口: {interface_str}")
                 print(f"IP地址: {ip_address.value.decode('utf-8')}")
@@ -58,7 +53,6 @@ def main():
                     print(f"信道: {channel.value.decode('utf-8')}")
                     print(f"Wi-Fi标准: {wifi_standard.value.decode('utf-8')}")
 
-                # 格式化输出（与nicInfo类似的格式）
                 if is_wifi.value:
                     wifi_info = f"{wifi_standard.value.decode('utf-8')} {band.value.decode('utf-8')}"
                     conn_info = f"{conn_type.value.decode('utf-8')} ({wifi_info}, {speed.value} Mbps)"


### PR DESCRIPTION
This pull request adds support for retrieving detailed network interface information on macOS using a new Swift-based dynamic library (`iokitNICLib`). It introduces both the Swift implementation for collecting NIC data via IOKit and CoreWLAN, and Python bindings to interact with this library. The macOS NIC backend is updated to use this new library as the primary method for NIC detection, with fallback to legacy shell commands if needed. Additionally, a test script is provided to validate the new library's functionality.

**Native macOS NIC library integration:**

* Added a new Swift dynamic library (`iokitNICLib.dylib`) that provides functions to retrieve the default network interface and detailed network information (including IP, speed, type, Wi-Fi band, and standard) using IOKit and CoreWLAN. (`src/pyhw/library/iokitNICLib/iokitNICLib.swift` [[1]](diffhunk://#diff-e5298b496be323b350242de4cdaecd8fca6c824b9d0f8a423b93245e1e83f9f0R1-R301) `src/pyhw/library/iokitNICLib/Makefile` [[2]](diffhunk://#diff-5f6555b6e60d20b77b84acf420595af79db5a2692c8e1c526d860873794215dcR1-R25)
* Updated the main `Makefile` to build the new NIC library as part of the overall build process. (`Makefile` [MakefileR8](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R8))

**Python backend enhancements:**

* Updated the macOS NIC backend to first attempt NIC info retrieval using the new IOKit-based library via `ctypes`, with fallback to shell commands. The Python code now gathers more detailed info, including connection type and speed, and formats the NIC list accordingly. (`src/pyhw/backend/nic/macos.py` [[1]](diffhunk://#diff-8002a601dab6fd3391a2933c701c0818ed90a060c6aba85f9f43894a2e9b9e26R3-R5) [[2]](diffhunk://#diff-8002a601dab6fd3391a2933c701c0818ed90a060c6aba85f9f43894a2e9b9e26L14-R191)

**Testing and validation:**

* Added a Python test script to load and verify the new NIC library, printing out detailed interface information for manual validation. (`src/pyhw/library/test/iokitNICLibTest.py` [src/pyhw/library/test/iokitNICLibTest.pyR1-R76](diffhunk://#diff-86a8c61b8519a5ed5c9d82f4495141737544771125ad04510e6812b551f53367R1-R76))