### PR TITLE
perf: use thread pool for detection

### DIFF
--- a/src/pyhw/__main__.py
+++ b/src/pyhw/__main__.py
@@ -15,104 +15,90 @@ from .pyhwUtil import createDataString
 from .pyhwUtil import getOS, selectOSLogo
 from .pyhwUtil import ReleaseChecker
 from .frontend.color import colorPrefix, colorSuffix, ColorSet
-import multiprocessing
+import concurrent.futures
+import queue
 import argparse
+import threading
 import time
-import functools
 
 
-def timed_function(func):
-    @functools.wraps(func)
-    def wrapper(debug_info, os, result_dict):
-        if not debug_info.get('debug', False):
-            return func(debug_info, os, result_dict)
-
-        start_time = time.time()
-        result = func(debug_info, os, result_dict)
-        elapsed = time.time() - start_time
-        debug_dict = debug_info.get('debug_dict', {})
-        if debug_dict is not None:
-            debug_dict[func.__name__] = elapsed
-        return result
-
-    wrapper.__module__ = func.__module__
-    return wrapper
+def check_release(release_queue):
+    release_checker = ReleaseChecker()
+    release_queue.put({
+        "is_new_release": release_checker.check_for_updates(),
+        "release": release_checker.LatestVersion,
+        "current": release_checker.CurrentVersion,
+        "is_in_pipx": release_checker.isInPIPX,
+    })
 
 
-def check_release(release_dict):
-    releaseChecker = ReleaseChecker()
-    release_dict["is_new_release"] = releaseChecker.check_for_updates()
-    release_dict["release"] = releaseChecker.LatestVersion
-    release_dict["current"] = releaseChecker.CurrentVersion
-    release_dict["is_in_pipx"] = releaseChecker.isInPIPX
+def detect_title(os):
+    return {"title": TitleDetect(os=os).getTitle().title}
 
 
-@timed_function
-def detect_title(debug_info, os, result_dict):
-    result_dict["title"] = TitleDetect(os=os).getTitle().title
+def detect_host(os):
+    return {"Host": HostDetect(os=os).getHostInfo().model}
 
 
-@timed_function
-def detect_host(debug_info, os, result_dict):
-    result_dict["Host"] = HostDetect(os=os).getHostInfo().model
+def detect_kernel(os):
+    return {"Kernel": KernelDetect(os=os).getKernelInfo().kernel}
 
 
-@timed_function
-def detect_kernel(debug_info, os, result_dict):
-    result_dict["Kernel"] = KernelDetect(os=os).getKernelInfo().kernel
+def detect_shell(os):
+    return {"Shell": ShellDetect(os=os).getShellInfo().info}
 
 
-@timed_function
-def detect_shell(debug_info, os, result_dict):
-    result_dict["Shell"] = ShellDetect(os=os).getShellInfo().info
+def detect_uptime(os):
+    return {"Uptime": UptimeDetect(os=os).getUptime().uptime}
 
 
-@timed_function
-def detect_uptime(debug_info, os, result_dict):
-    result_dict["Uptime"] = UptimeDetect(os=os).getUptime().uptime
+def detect_os(os):
+    return {"OS": OSDetect(os=os).getOSInfo().prettyName}
 
 
-@timed_function
-def detect_os(debug_info, os, result_dict):
-    result_dict["OS"] = OSDetect(os=os).getOSInfo().prettyName
+def detect_cpu(os):
+    return {"CPU": CPUDetect(os=os).getCPUInfo().cpu}
 
 
-@timed_function
-def detect_cpu(debug_info, os, result_dict):
-    result_dict["CPU"] = CPUDetect(os=os).getCPUInfo().cpu
-
-
-@timed_function
-def detect_gpu(debug_info, os, result_dict):
+def detect_gpu(os):
     gpu_info = GPUDetect(os=os).getGPUInfo()
     if gpu_info.number > 0:
-        result_dict["GPU"] = gpu_info.gpus
+        return {"GPU": gpu_info.gpus}
+    return {}
 
 
-@timed_function
-def detect_memory(debug_info, os, result_dict):
-    result_dict["Memory"] = MemoryDetect(os=os).getMemoryInfo().memory
+def detect_memory(os):
+    return {"Memory": MemoryDetect(os=os).getMemoryInfo().memory}
 
 
-@timed_function
-def detect_nic(debug_info, os, result_dict):
+def detect_nic(os):
     nic_info = NICDetect(os=os).getNICInfo()
     if nic_info.number > 0:
-        result_dict["NIC"] = nic_info.nics
+        return {"NIC": nic_info.nics}
+    return {}
 
 
-@timed_function
-def detect_npu(debug_info, os, result_dict):
+def detect_npu(os):
     npu_info = NPUDetect(os=os).getNPUInfo()
     if npu_info.number > 0:
-        result_dict["NPU"] = npu_info.npus
+        return {"NPU": npu_info.npus}
+    return {}
 
 
-@timed_function
-def detect_pci_related(debug_info, os, result_dict):
-    detect_gpu(debug_info, os, result_dict)
-    detect_nic(debug_info, os, result_dict)
-    detect_npu(debug_info, os, result_dict)
+def detect_pci_related(os):
+    result = {}
+    result.update(detect_gpu(os))
+    result.update(detect_nic(os))
+    result.update(detect_npu(os))
+    return result
+
+
+def run_detector(name, func, os):
+    start_time = time.time()
+    try:
+        return name, func(os), time.time() - start_time, None
+    except Exception as exc:
+        return name, {}, time.time() - start_time, repr(exc)
 
 
 def print_version():
@@ -138,40 +124,49 @@ def main():
 
     data = Data()
 
-    manager = multiprocessing.Manager()
-    result_dict = manager.dict()
-    release_dict = manager.dict()
-    debug_dict = manager.dict() if args.debug else None
-    debug_info = {'debug': args.debug, 'debug_dict': debug_dict}
+    release_queue = queue.Queue()
+    release_thread = threading.Thread(target=check_release, args=(release_queue,), daemon=True)
 
-    processes = [
-        multiprocessing.Process(target=check_release, args=(release_dict,)),
-        multiprocessing.Process(target=detect_title, args=(debug_info, current_os, result_dict)),
-        multiprocessing.Process(target=detect_host, args=(debug_info, current_os, result_dict)),
-        multiprocessing.Process(target=detect_kernel, args=(debug_info, current_os, result_dict)),
-        multiprocessing.Process(target=detect_shell, args=(debug_info, current_os, result_dict)),
-        multiprocessing.Process(target=detect_uptime, args=(debug_info, current_os, result_dict)),
-        multiprocessing.Process(target=detect_os, args=(debug_info, current_os, result_dict)),
-        multiprocessing.Process(target=detect_cpu, args=(debug_info, current_os, result_dict)),
-        multiprocessing.Process(target=detect_memory, args=(debug_info, current_os, result_dict)),
+    detector_tasks = [
+        ("title", detect_title),
+        ("host", detect_host),
+        ("kernel", detect_kernel),
+        ("shell", detect_shell),
+        ("uptime", detect_uptime),
+        ("os", detect_os),
+        ("cpu", detect_cpu),
+        ("memory", detect_memory),
     ]
 
     if current_os == "macos":
-        processes.append(multiprocessing.Process(target=detect_gpu, args=(debug_info, current_os, result_dict)))
-        processes.append(multiprocessing.Process(target=detect_nic, args=(debug_info, current_os, result_dict)))
-        processes.append(multiprocessing.Process(target=detect_npu, args=(debug_info, current_os, result_dict)))
+        detector_tasks.extend([
+            ("gpu", detect_gpu),
+            ("nic", detect_nic),
+            ("npu", detect_npu),
+        ])
     else:
-        processes.append(multiprocessing.Process(target=detect_pci_related, args=(debug_info, current_os, result_dict)))
+        detector_tasks.append(("pci_related", detect_pci_related))
 
     start_time = time.time()
-    for process in processes:
-        process.start()
+    release_thread.start()
+    result_dict = {}
+    debug_dict = {}
+    detector_errors = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(detector_tasks)) as executor:
+        futures = [
+            executor.submit(run_detector, name, func, current_os)
+            for name, func in detector_tasks
+        ]
+        for future in concurrent.futures.as_completed(futures):
+            name, result, elapsed, error = future.result()
+            if error is None:
+                result_dict.update(result)
+            else:
+                detector_errors.append(f"{name}: {error}")
+            if args.debug:
+                debug_dict[name] = elapsed
 
     detection_time = time.time() - start_time
-
-    for process in processes[1:]:
-        process.join()
-
     total_time = time.time() - start_time
 
     for key, value in result_dict.items():
@@ -185,22 +180,19 @@ def main():
         print(f"🔍 DEBUG MODE: Timing Information")
         print("="*50)
         for func_name, elapsed in debug_dict.items():
-            detection_name = func_name.replace("detect_", "")
-            print(f"{detection_name:<10}: {elapsed:.4f} s")
+            print(f"{func_name:<10}: {elapsed:.4f} s")
+        for error in detector_errors:
+            print(f"error     : {error}")
         print("-" * 50)
-        print(f"Total create time: {detection_time:.4f} s")
+        print(f"Total detection time: {detection_time:.4f} s")
         print("-"*50)
         print(f"Total execution time: {total_time:.4f} s")
         print("="*50)
 
-    timeout = 3
-    processes[0].join(timeout)
-    if processes[0].is_alive():
-        processes[0].terminate()
-        processes[0].join()
-        release_dict["is_new_release"] = False
-    else:
-        pass
+    try:
+        release_dict = release_queue.get(timeout=3)
+    except queue.Empty:
+        release_dict = {"is_new_release": False}
 
     if release_dict["is_new_release"]:
         print(f"🔔 Found a newer version: v{release_dict['release']} (current: v{release_dict['current']})")

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,7 +1,5 @@
-import pytest
-from pyhw.__main__ import main
+from pyhw.__main__ import main, run_detector
 import sys
-import multiprocessing
 
 
 def test_main_version(monkeypatch, capsys):
@@ -28,33 +26,21 @@ def test_main_unsupported_os(monkeypatch, capsys):
     assert "Only Linux, macOS, FreeBSD, and Windows are supported" in captured.out
 
 
+def test_run_detector_catches_exception():
+    def failing_detector(os):
+        raise RuntimeError(f"failed on {os}")
+
+    name, result, elapsed, error = run_detector("failing", failing_detector, "macos")
+
+    assert name == "failing"
+    assert result == {}
+    assert elapsed >= 0
+    assert "RuntimeError" in error
+
+
 def test_main_run(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["pyhw", "--debug"])
     monkeypatch.setattr("pyhw.__main__.getOS", lambda: "linux")
-    
-    # Mock multiprocessing Process to run synchronously
-    class MockProcess:
-        def __init__(self, target, args=()):
-            self.target = target
-            self.args = args
-            
-        def start(self):
-            self.target(*self.args)
-            
-        def join(self, timeout=None):
-            pass
-            
-        def terminate(self):
-            pass
-            
-        def is_alive(self):
-            # Test the condition where it's still alive to trigger termination logic
-            if getattr(self, "_checked", False):
-                return False
-            self._checked = True
-            return True
-            
-    monkeypatch.setattr(multiprocessing, "Process", MockProcess)
     
     # Mock backend detects to avoid errors
     class MockInfo:
@@ -112,26 +98,6 @@ def test_main_run(monkeypatch):
 def test_main_run_macos(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["pyhw"])
     monkeypatch.setattr("pyhw.__main__.getOS", lambda: "macos")
-    
-    # Mock multiprocessing Process to run synchronously
-    class MockProcess:
-        def __init__(self, target, args=()):
-            self.target = target
-            self.args = args
-            
-        def start(self):
-            self.target(*self.args)
-            
-        def join(self, timeout=None):
-            pass
-            
-        def terminate(self):
-            pass
-            
-        def is_alive(self):
-            return False
-            
-    monkeypatch.setattr(multiprocessing, "Process", MockProcess)
     
     # Mock backend detects to avoid errors
     class MockInfo:


### PR DESCRIPTION
## Summary

- Replace detector multiprocessing with `ThreadPoolExecutor`
- Keep detector failures isolated with per-detector exception capture
- Move release update check to a daemon thread to avoid `python -m pyhw` multiprocessing spawn issues
- Update main tests for the thread-based execution path

## Validation

- `.venv/bin/python -m pytest`
- macOS CLI smoke run with `.venv/bin/python -m pyhw --debug`

## Notes

ThreadPoolExecutor showed significantly better macOS detection latency in local benchmarking. Python exceptions are caught per detector; native Swift/C fatal aborts remain outside Python exception handling.